### PR TITLE
Handle empty files in state storage loading

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -30,6 +30,9 @@ pub fn load_from_path(path: Option<PathBuf>) -> io::Result<StateMap> {
     }
 
     let content = fs::read_to_string(&path)?;
+    if content.trim().is_empty() {
+        return Ok(HashMap::new());
+    }
     let state: StateMap = serde_json::from_str(&content).map_err(|e| {
         io::Error::new(
             io::ErrorKind::InvalidData,


### PR DESCRIPTION
## Summary
Added a check to handle empty or whitespace-only files when loading state from storage, returning an empty HashMap instead of attempting to parse invalid JSON.

## Changes
- Added validation in `load_from_path()` to detect empty files before JSON deserialization
- Returns an empty `HashMap` when the file content is empty or contains only whitespace
- Prevents JSON parsing errors that would occur when attempting to deserialize empty content

## Implementation Details
The check uses `content.trim().is_empty()` to handle both completely empty files and files containing only whitespace characters. This gracefully handles the edge case where a state file exists but is empty, which can occur during initialization or after file truncation.

https://claude.ai/code/session_01GJiii1VQF3RMnzzhALnPcD